### PR TITLE
Alternative Redirect Path on Failure

### DIFF
--- a/conf/agile-ui-conf.js
+++ b/conf/agile-ui-conf.js
@@ -4,6 +4,7 @@ module.exports = {
     "dbName": "./database_web",
     "createTables": true
   },
+  "failureRedirect": "/login",
   "auth": {
     "github": {
       "clientID": "getGithubId",

--- a/routes/oauth2-routes.js
+++ b/routes/oauth2-routes.js
@@ -53,7 +53,7 @@ function oauth2Router(tokenconf, entityStorageConf) {
   // authorization).  We accomplish that here by routing through `ensureLoggedIn()`
   // first, and rendering the `dialog` view.
   var authorization = [
-    login.ensureLoggedIn(),
+    login.ensureLoggedIn(tokenconf && tokenconf.failureRedirect ? tokenconf.failureRedirect : undefined),
     server.authorization(function (clientID, redirectURI, done) {
       db.clients.findByClientId(clientID, function (err, client) {
         if (err) {
@@ -106,7 +106,7 @@ function oauth2Router(tokenconf, entityStorageConf) {
   // a response.
 
   var decision = [
-    login.ensureLoggedIn(),
+    login.ensureLoggedIn(tokenconf && tokenconf.failureRedirect ? tokenconf.failureRedirect : undefined),
     server.decision() //probably the PDP should have to be placed here (receive request and verify what the PDP says. Just get the post...)
   ];
 


### PR DESCRIPTION
Extended config files and routes implementation to allow for alternative "login" path (original default was '/login')

If specified the indicated path, if undefined, the default path '/login', is used.